### PR TITLE
Change target configuration to omit soft device

### DIFF
--- a/.yotta.json
+++ b/.yotta.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "target": "calliope-mini-classic-gcc,*",
+    "target": "calliope-mini-classic-gcc-nosd,*",
     "targetSetExplicitly": true
   }
 }


### PR DESCRIPTION
For simple programs, the Nordic Semiconductor Soft Device is unnecessary. 
It takes up memory and may configure interrupts. 
The nosoftdevice branch selects and downloads the target without soft device. 
I suggest not to merge this branch into `master`, but keep it as separate branch.

`yotta target calliope-mini-classic-gcc-nosd`
has the same effect, but you have to know in advance that the calliope-mini-classic-gcc-nosd target exists and is available for `yotta update`.

For details, see the [calliope-mini/calliope-mini-targets](https://github.com/calliope-mini/calliope-mini-targets) repository.

Signed-off-by: Christoph Maier <cm.hardware.software.elsewhere@gmail.com>